### PR TITLE
Docs: randomness examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,5 @@ npx @phala/fn watch <Your Contract Address> <Your Contract JSON File> dist/index
 - [VIEM ABI Codec](examples/viem-abi-codec/index.ts)
 - [SCALE Codec](examples/scale-codec/index.ts)
 - [Call pink.invokeContract](examples/scale-codec/index.ts)
+- [Chainlink compatible VRF](examples/randomness-fullfillrandomwords)
+- [Randrange](examples/randomness-randrange)

--- a/examples/randomness-fullfillrandomwords/index.ts
+++ b/examples/randomness-fullfillrandomwords/index.ts
@@ -1,0 +1,23 @@
+import { vrf } from "@phala/pink-env";
+import { encodeAbiParameters, decodeAbiParameters } from 'viem'
+
+type Hex = `0x${string}`
+
+/**
+ * This function responses with requestId and the randomness result, which you
+ * can implemented same same `fullfillRandomWords` as Chainlink VRF callback.
+ */
+export default function main(payload: Hex) {
+  const [requestId, seed] = decodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'bytes' }],
+    payload
+  )
+  const randomness = vrf(seed)
+  return encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'uint256[]' }],
+    [
+      requestId,
+      Array.from(randomness).map(i => BigInt(i))
+    ]
+  )
+}

--- a/examples/randomness-randrange/index.ts
+++ b/examples/randomness-randrange/index.ts
@@ -1,0 +1,26 @@
+import { vrf } from "@phala/pink-env";
+import { encodeAbiParameters, decodeAbiParameters } from 'viem'
+
+type Hex = `0x${string}`
+
+export default function main(payload: Hex) {
+  const [requestId, seed, start, stop] = decodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'bytes' }, { type: 'uint8' }, { type: 'uint8' }],
+    payload
+  )
+  const randomness = vrf(seed)
+  let randomNum = randomness[0]
+  let j = 0
+  while (randomNum < stop && j++ < randomness.length) {
+    randomNum = randomNum + (randomness[j] << 8 * j)
+  }
+  randomNum = randomNum % (stop - start) + start
+
+  return encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'uint256' }],
+    [
+      requestId,
+      BigInt(randomNum)
+    ]
+  )
+}


### PR DESCRIPTION
This PR added two examples for VRF.
- `fullfillRandomWords`: Chainlink VRF like randomness.
- `randrange`: get a random number within specified number range, it works like [`random.randrange`](https://docs.python.org/3/library/random.html#random.randrange) in Python.